### PR TITLE
Fix substitution of variables being used in a string template

### DIFF
--- a/build.py
+++ b/build.py
@@ -227,6 +227,7 @@ def identity(x): return x
 def rename_variables_in_less_file(variable_renames, content):
     for (name, new_name) in variable_renames:
         content = re.sub(r'@' + name + r'([^A-Za-z])',  '@' + new_name + '\\1', content)
+        content = re.sub(r'@{' + name + r'}',  '@{' + new_name + '}', content)
     return content
 
 


### PR DESCRIPTION
Fixes: https://circleci.com/gh/squirly/semantic-ui-less-importable/11#tests/containers/0

Fix the `rename_variables_in_less_file` for things like

`url("@{fontPath}/@{outlineFontName}.woff2") format(\'woff2\’),`

where the name of the variable to be replaced is in `{}`.